### PR TITLE
Configurando rastreador de codigo e OpenTracing e jaeger no projeto

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,16 @@ services:
       MYSQL_PASSWORD: gvendas
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: gvendas_db 
+      
+  jaeger:
+    image: jaegertracing/all-in-one:1.24 
+    container_name: jaeger
+    ports:
+       - 5775:5775/udp
+       - 6831:6831/udp
+       - 6832:6832/udp 
+       - 5778:5778 
+       - 16686:16686 
+       - 14268:14268 
+       - 14250:14250 
+       - 9411:9411 

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,13 @@
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		
+		<dependency>
+		  <groupId>io.opentracing.contrib</groupId>
+		  <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+		  <version>3.2.2</version>
+       </dependency>
+		
+		
 	   <dependency>
 		    <groupId>io.springfox</groupId>
 		    <artifactId>springfox-swagger2</artifactId>

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,12 @@
+{"properties": [
+  {
+    "name": "opentracing.jaeger.sampler-type",
+    "type": "java.lang.String",
+    "description": "A description for 'opentracing.jaeger.sampler-type'"
+  },
+  {
+    "name": "opentracing.jaeger.sampler-param",
+    "type": "java.lang.String",
+    "description": "A description for 'opentracing.jaeger.sampler-param'"
+  }
+]}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,10 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.database=MYSQL
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+
+#configurando TRACING (Jaeger)
+opentracing.jaeger.service-name=gestao-vendas
+opentracing.jaeger.udp-sender.host=localhost
+opentracing.jaeger.udp-sender.port=6831
+opentracing.jaeger.sampler-type=const
+opentracing.jaeger.sampler-param=1


### PR DESCRIPTION
## Status
**PRONTO**

## Descrição
Configurando rastreador de codigo e OpenTracing e jaeger no projeto

## Todos
- [] Testes
- [] Documentação

## Etapas para testar ou reproduzir

Primeiro execute o maven 
 
```
 mvn package
```
Em seguida faça

```
 target/gestao-vendas-1.0-SNAPSHOT.jar
```
